### PR TITLE
Add Starchasers-Programs to repo.cfg

### DIFF
--- a/repos.cfg
+++ b/repos.cfg
@@ -130,6 +130,9 @@
 	["Wuerfel_21's programs"]={
 		repo="OpenPrograms/Wuerfel_21-OC-Toolkit",
 	},
+	["Starchasers programs"]={
+		repo="OpenPrograms/Starchasers-Programs",
+	},
 	["Miscellaneous programs"]={
 		repo="OpenPrograms/MiscPrograms",
 	},


### PR DESCRIPTION
I have no idea how to get the generate.lua script to work.
I've installed luasec using luarocks but lua still can't find the module, module search patch is probably wrong but I don't know why.